### PR TITLE
branch=main in the mobile-broadband-provider-info recipe file

### DIFF
--- a/recipes-core/fixes/mobile-broadband-provider-info_git.bbappend
+++ b/recipes-core/fixes/mobile-broadband-provider-info_git.bbappend
@@ -1,0 +1,2 @@
+# replaces branch=master with branch=main in the mobile-broadband-provider-info recipe file
+SRC_URI = "git://gitlab.gnome.org/GNOME/mobile-broadband-provider-info.git;protocol=https;branch=main"


### PR DESCRIPTION
it replaces `branch=master` with `branch=main` in the mobile-broadband-provider-info recipe file