### PR TITLE
Add build yocto github action

### DIFF
--- a/.github/workflows/build-yocto.yml
+++ b/.github/workflows/build-yocto.yml
@@ -1,0 +1,40 @@
+name: Build Yocto Image
+
+on:
+  push:
+    branches: [ "master", "develop" ]
+  pull_request:
+    branches: [ "master", "develop" ]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+    
+jobs:
+  build-yocto:
+    runs-on: self-hosted
+    
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        repository: MistySOM/rzg2l
+        submodules: recursive
+    
+    - run: |
+        cd Build/meta-mistysom
+        git checkout ${{github.ref}}
+        cd ../..
+    
+    - name: Build the Docker image
+      run: cd Build && ./build.sh; 
+    
+    - name: Run the Docker image and build output files with SDK
+      run: cd Build && ./run.sh -c /home/github/rzg2l-cache;
+      
+    - name: Upload artifacts
+      uses: actions/upload-artifact@v3
+      with:
+        name: output-files
+        path: |
+          Build/output/images/smarc-rzg2l/Image-smarc-rzg2l.bin
+          Build/output/images/smarc-rzg2l/r9a07g044l2-smarc.dtb
+          Build/output/images/smarc-rzg2l/mistysom-image-smarc-rzg2l.tar.bz2

--- a/.github/workflows/build-yocto.yml
+++ b/.github/workflows/build-yocto.yml
@@ -21,7 +21,6 @@ jobs:
     - uses: actions/checkout@v3
       with:
         repository: MistySOM/rzg2l
-        submodules: true
         path: rzg2l
     
     - run: |

--- a/.github/workflows/build-yocto.yml
+++ b/.github/workflows/build-yocto.yml
@@ -16,14 +16,18 @@ jobs:
     steps:
     - uses: actions/checkout@v3
       with:
+        path: meta-mistysom
+
+    - uses: actions/checkout@v3
+      with:
         repository: MistySOM/rzg2l
         submodules: recursive
+        path: rzg2l
     
     - run: |
-        cd Build/meta-mistysom
-        git fetch --all
-        git checkout ${GITHUB_SHA}
-        cd ../..
+        rm -rf rzg2l/Build/meta-mistysom
+        mv meta-mistysom rzg2l/Build
+        mv rzg2l/* .
     
     - name: Build the Docker image
       run: cd Build && ./build.sh; 

--- a/.github/workflows/build-yocto.yml
+++ b/.github/workflows/build-yocto.yml
@@ -26,8 +26,9 @@ jobs:
     
     - run: |
         rm -rf rzg2l/Build/meta-mistysom
-        mv meta-mistysom rzg2l/Build
-        mv rzg2l/* .
+        cp meta-mistysom rzg2l/Build
+        cp rzg2l/* .
+        rm -rf meta-mistysom rzg2l        
     
     - name: Build the Docker image
       run: cd Build && ./build.sh; 

--- a/.github/workflows/build-yocto.yml
+++ b/.github/workflows/build-yocto.yml
@@ -13,21 +13,14 @@ jobs:
   build-yocto:
     runs-on: self-hosted
     
-    steps:
-    - uses: actions/checkout@v3
-      with:
-        path: meta-mistysom
-
+    steps:    
     - uses: actions/checkout@v3
       with:
         repository: MistySOM/rzg2l
-        path: rzg2l
-    
-    - run: |
-        rm -rf rzg2l/Build/meta-mistysom/*
-        cp -r meta-mistysom rzg2l/Build
-        cp -r rzg2l/* .
-        rm -rf meta-mistysom rzg2l        
+
+    - uses: actions/checkout@v3
+      with:
+        path: Build/meta-mistysom
     
     - name: Build the Docker image
       run: cd Build && ./build.sh; 

--- a/.github/workflows/build-yocto.yml
+++ b/.github/workflows/build-yocto.yml
@@ -20,13 +20,8 @@ jobs:
         submodules: recursive
     
     - run: |
-        target_branch=${{ github.base_ref }}
-        # Set another value if the variable is empty
-        target_branch="${target_branch:-${{ github.ref_name }}}"        
-        echo "The target branch is: $target_branch"
-        
         cd Build/meta-mistysom        
-        git checkout ${target_branch}
+        git checkout ${{github.sha}}
         cd ../..
     
     - name: Build the Docker image

--- a/.github/workflows/build-yocto.yml
+++ b/.github/workflows/build-yocto.yml
@@ -18,10 +18,10 @@ jobs:
       with:
         repository: MistySOM/rzg2l
         submodules: recursive
-        fetch-depth: 0
     
     - run: |
-        cd Build/meta-mistysom        
+        cd Build/meta-mistysom
+        git fetch --all
         git checkout ${{github.sha}}
         cd ../..
     

--- a/.github/workflows/build-yocto.yml
+++ b/.github/workflows/build-yocto.yml
@@ -24,6 +24,7 @@ jobs:
         path: rzg2l
     
     - run: |
+        rm -rf rzg2l/Build/meta-mistysom
         cp -r meta-mistysom rzg2l/Build
         cp -r rzg2l/* .
         rm -rf meta-mistysom rzg2l        

--- a/.github/workflows/build-yocto.yml
+++ b/.github/workflows/build-yocto.yml
@@ -21,7 +21,7 @@ jobs:
     - uses: actions/checkout@v3
       with:
         repository: MistySOM/rzg2l
-        submodules: recursive
+        submodules: true
         path: rzg2l
     
     - run: |

--- a/.github/workflows/build-yocto.yml
+++ b/.github/workflows/build-yocto.yml
@@ -24,9 +24,8 @@ jobs:
         path: rzg2l
     
     - run: |
-        rm -rf rzg2l/Build/meta-mistysom
-        cp meta-mistysom rzg2l/Build
-        cp rzg2l/* .
+        cp -r meta-mistysom rzg2l/Build
+        cp -r rzg2l/* .
         rm -rf meta-mistysom rzg2l        
     
     - name: Build the Docker image

--- a/.github/workflows/build-yocto.yml
+++ b/.github/workflows/build-yocto.yml
@@ -25,8 +25,8 @@ jobs:
     
     - run: |
         rm -rf rzg2l/Build/meta-mistysom
-        cp -r meta-mistysom rzg2l/Build
-        cp -r rzg2l/* .
+        cp -r meta-mistysom rzg2l/Build/
+        cp -r rzg2l/* ./
         rm -rf meta-mistysom rzg2l        
     
     - name: Build the Docker image

--- a/.github/workflows/build-yocto.yml
+++ b/.github/workflows/build-yocto.yml
@@ -21,7 +21,7 @@ jobs:
     
     - run: |
         cd Build/meta-mistysom
-        git checkout ${{github.ref}}
+        git checkout ${{github.ref_name}}
         cd ../..
     
     - name: Build the Docker image

--- a/.github/workflows/build-yocto.yml
+++ b/.github/workflows/build-yocto.yml
@@ -22,7 +22,7 @@ jobs:
     - run: |
         cd Build/meta-mistysom
         git fetch --all
-        git checkout ${{github.sha}}
+        git checkout ${GITHUB_SHA}
         cd ../..
     
     - name: Build the Docker image

--- a/.github/workflows/build-yocto.yml
+++ b/.github/workflows/build-yocto.yml
@@ -24,9 +24,9 @@ jobs:
         path: rzg2l
     
     - run: |
-        rm -rf rzg2l/Build/meta-mistysom
-        cp -r meta-mistysom rzg2l/Build/
-        cp -r rzg2l/* ./
+        rm -rf rzg2l/Build/meta-mistysom/*
+        cp -r meta-mistysom rzg2l/Build
+        cp -r rzg2l/* .
         rm -rf meta-mistysom rzg2l        
     
     - name: Build the Docker image

--- a/.github/workflows/build-yocto.yml
+++ b/.github/workflows/build-yocto.yml
@@ -18,6 +18,7 @@ jobs:
       with:
         repository: MistySOM/rzg2l
         submodules: recursive
+        fetch-depth: 0
     
     - run: |
         cd Build/meta-mistysom        

--- a/.github/workflows/build-yocto.yml
+++ b/.github/workflows/build-yocto.yml
@@ -20,8 +20,13 @@ jobs:
         submodules: recursive
     
     - run: |
-        cd Build/meta-mistysom
-        git checkout ${{github.ref_name}}
+        target_branch=${{ github.base_ref }}
+        # Set another value if the variable is empty
+        target_branch="${target_branch:-${{ github.ref_name }}}"        
+        echo "The target branch is: $target_branch"
+        
+        cd Build/meta-mistysom        
+        git checkout ${target_branch}
         cd ../..
     
     - name: Build the Docker image


### PR DESCRIPTION
I noticed that our changes in the meta-mistysom repo will not get tested on yocto until either rzg2l or rzv2l repos update their submodule. This delay can add some confusion later.

In this pull request, I am adding yocto build test of the rzg2l repo with the latest meta-mistysom change.