### PR TITLE
Fix build yocto workflow

### DIFF
--- a/.github/workflows/build-yocto.yml
+++ b/.github/workflows/build-yocto.yml
@@ -22,7 +22,7 @@ jobs:
 
     - uses: actions/checkout@v3
       with:
-        submodule: recursive
+        submodules: recursive
         path: meta-mistysom
 
     - run: |

--- a/.github/workflows/build-yocto.yml
+++ b/.github/workflows/build-yocto.yml
@@ -23,7 +23,6 @@ jobs:
 
     - uses: actions/checkout@v3
       with:
-        repository: MistySOM/meta-mistysom
         path: meta-mistysom
 
     - run: |

--- a/.github/workflows/build-yocto.yml
+++ b/.github/workflows/build-yocto.yml
@@ -11,7 +11,7 @@ on:
     
 jobs:
   build-yocto:
-    runs-on: self-hosted
+    runs-on: DC02
     
     steps:    
     - uses: actions/checkout@v3
@@ -22,6 +22,7 @@ jobs:
 
     - uses: actions/checkout@v3
       with:
+        submodule: recursive
         path: meta-mistysom
 
     - run: |

--- a/.github/workflows/build-yocto.yml
+++ b/.github/workflows/build-yocto.yml
@@ -19,10 +19,11 @@ jobs:
         repository: MistySOM/rzg2l
         path: rzg2l
         ref: develop
+        submodules: recursive
 
     - uses: actions/checkout@v3
       with:
-        submodules: recursive
+        repository: MistySOM/meta-mistysom
         path: meta-mistysom
 
     - run: |

--- a/.github/workflows/build-yocto.yml
+++ b/.github/workflows/build-yocto.yml
@@ -19,7 +19,7 @@ jobs:
         repository: MistySOM/rzg2l
         path: rzg2l
         ref: develop
-        submodules: recursive
+        submodules: true
 
     - uses: actions/checkout@v3
       with:


### PR DESCRIPTION
In this pull request, I am narrowing the runner to only DC02 so it wouldn't confuse the new self-hosted runner on DC01 (used for the wiki)
Also, as we have a new submodule for laird lwb5p, we need to checkout the rzg2l with submodules.