### PR TITLE
Fix kernel devicetree append patch for running bitbake multiple times

### DIFF
--- a/recipes-kernel/linux/linux-renesas_%.bbappend
+++ b/recipes-kernel/linux/linux-renesas_%.bbappend
@@ -15,6 +15,7 @@ SRC_URI += "file://0001-remove-sdhi1-uhs.patch"
 SRC_URI += "file://0002-add-sdhi1-laird.patch"
 SRC_URI += "file://add-vsc8531-ethernet.dts"
 SRC_URI += "file://add-can-ports.dts"
+DT = "${@d.getVar('KERNEL_DEVICETREE', True).strip().rsplit('/', 1)[-1].rsplit('.', 1)[0]}"
 
 # Uncomment any patches here for which you wish to enable specific features for hardware testing
 #SRC_URI += "file://add-sx150x-port-expander.dts"
@@ -24,7 +25,10 @@ SRC_URI += "file://add-can-ports.dts"
 #SRC_URI += "file://add-riic1-i2c1-for-testing-i2c-on-hdr.dts"
 
 do_patch_append() {
-    cat ${WORKDIR}/*.dts >> ${S}/arch/arm64/boot/dts/renesas/r9a07g044l2-smarc.dts || :
-    cat ${WORKDIR}/*.dts >> ${S}/arch/arm64/boot/dts/renesas/r9a07g054l2-smarc.dts || :
+    cp ${S}/arch/arm64/boot/dts/renesas/${DT}.dts ${WORKDIR}/${DT}.dts.orig
+    cat ${WORKDIR}/*.dts >> ${S}/arch/arm64/boot/dts/renesas/${DT}.dts || :
 }
 
+do_compile_append() {
+    cp ${WORKDIR}/${DT}.dts.orig ${S}/arch/arm64/boot/dts/renesas/${DT}.dts
+}

--- a/recipes-kernel/linux/linux-renesas_%.bbappend
+++ b/recipes-kernel/linux/linux-renesas_%.bbappend
@@ -15,7 +15,6 @@ SRC_URI += "file://0001-remove-sdhi1-uhs.patch"
 SRC_URI += "file://0002-add-sdhi1-laird.patch"
 SRC_URI += "file://add-vsc8531-ethernet.dts"
 SRC_URI += "file://add-can-ports.dts"
-DT = "${@d.getVar('KERNEL_DEVICETREE', True).strip().rsplit('/', 1)[-1].rsplit('.', 1)[0]}"
 
 # Uncomment any patches here for which you wish to enable specific features for hardware testing
 #SRC_URI += "file://add-sx150x-port-expander.dts"
@@ -24,11 +23,19 @@ DT = "${@d.getVar('KERNEL_DEVICETREE', True).strip().rsplit('/', 1)[-1].rsplit('
 #SRC_URI += "file://add-scif2-serial-port-for-uart-testing.dts"
 #SRC_URI += "file://add-riic1-i2c1-for-testing-i2c-on-hdr.dts"
 
+# The ${KERNEL_DEVICETREE} variable contains '   renesas/r9a07g044l2-smarc.dtb    ';
+# So the extra whitespaces needs to removed with strip() function,
+# We can extract the file name and remove the directory name with rsplit('/', 1)[-1] function,
+# And lastly, we can remove the extension with rsplit('.',1)[0] function resulting in 'r9a07g044l2-smarc'
+DT = "${@d.getVar('KERNEL_DEVICETREE', True).strip().rsplit('/', 1)[-1].rsplit('.', 1)[0]}"
+
+# Using this ${DT} variable we can backup and patch the correct devicetree.
 do_patch_append() {
     cp ${S}/arch/arm64/boot/dts/renesas/${DT}.dts ${WORKDIR}/${DT}.dts.orig
     cat ${WORKDIR}/*.dts >> ${S}/arch/arm64/boot/dts/renesas/${DT}.dts || :
 }
 
+# Restore backup, allowing to have multiple 'bitbake mistysom-image' executions.
 do_deploy_append() {
     cp ${WORKDIR}/${DT}.dts.orig ${S}/arch/arm64/boot/dts/renesas/${DT}.dts
 }

--- a/recipes-kernel/linux/linux-renesas_%.bbappend
+++ b/recipes-kernel/linux/linux-renesas_%.bbappend
@@ -29,6 +29,6 @@ do_patch_append() {
     cat ${WORKDIR}/*.dts >> ${S}/arch/arm64/boot/dts/renesas/${DT}.dts || :
 }
 
-do_compile_append() {
+do_deploy_append() {
     cp ${WORKDIR}/${DT}.dts.orig ${S}/arch/arm64/boot/dts/renesas/${DT}.dts
 }


### PR DESCRIPTION
I noticed that if you run `bitbake mistysom-image` multiple times, the patches get appended multiple times to the `r9a07g044l2-smarc.dts` file. Which was kinda okay because they were all overriding the same values again and again.

But with the new econ patches, I noticed that if there is a `delete-note` command, it throws an error saying that the node is already deleted and I can't find it to delete it again, resulting in the build failure.

So in this pull request, I am taking a backup from the devicetree source file and I restore the backup after the kernel deployment is over. So you could run the bitbake command multiple times and the append would result to the same outcome.

Additionally, instead of patching both devicetree files, I only run it on the one that the bitbake is using for the build using a python code and the DT variable.