### PR TITLE
Add wic.bz2 image output

### DIFF
--- a/.github/workflows/build-yocto.yml
+++ b/.github/workflows/build-yocto.yml
@@ -42,6 +42,4 @@ jobs:
       uses: actions/upload-artifact@v3
       with:
         name: output-files
-        path: |
-          rzg2l/Build/output/images/smarc-rzg2l/mistysom-image-smarc-rzg2l.wic.bz2
-          rzg2l/Build/output/images/smarc-rzg2l/mistysom-image-smarc-rzg2l.ext4.bz2
+        path: rzg2l/Build/output/images/smarc-rzg2l/mistysom-image-smarc-rzg2l.wic.bz2

--- a/.github/workflows/build-yocto.yml
+++ b/.github/workflows/build-yocto.yml
@@ -40,6 +40,5 @@ jobs:
       with:
         name: output-files
         path: |
-          $GITHUB_WORKSPACE/rzg2l/Build/output/images/smarc-rzg2l/Image-smarc-rzg2l.bin
-          $GITHUB_WORKSPACE/rzg2l/Build/output/images/smarc-rzg2l/r9a07g044l2-smarc.dtb
-          $GITHUB_WORKSPACE/rzg2l/Build/output/images/smarc-rzg2l/mistysom-image-smarc-rzg2l.tar.bz2
+          $GITHUB_WORKSPACE/rzg2l/Build/output/images/smarc-rzg2l/mistysom-image-smarc-rzg2l.wic.bz2
+          $GITHUB_WORKSPACE/rzg2l/Build/output/images/smarc-rzg2l/mistysom-image-smarc-rzg2l.ext4.bz2

--- a/.github/workflows/build-yocto.yml
+++ b/.github/workflows/build-yocto.yml
@@ -26,22 +26,22 @@ jobs:
         path: meta-mistysom
 
     - run: |
-        rm -rf $GITHUB_WORKSPACE/rzg2l/Build/meta-mistysom
-        cp -r $GITHUB_WORKSPACE/meta-mistysom $GITHUB_WORKSPACE/rzg2l/Build/
+        rm -rf rzg2l/Build/meta-mistysom
+        cp -r meta-mistysom rzg2l/Build/
 
     - name: Build the Docker image
-      run: cd $GITHUB_WORKSPACE/rzg2l/Build && ./build.sh; 
+      run: cd rzg2l/Build && ./build.sh;
     
     - name: Run the Docker image and build output files with SDK
-      run: cd $GITHUB_WORKSPACE/rzg2l/Build && ./run.sh -c /home/github/rzg2l-cache;
+      run: cd rzg2l/Build && ./run.sh -c /home/github/rzg2l-cache;
 
     - name: List files that are generated
-      run: ls -lah $GITHUB_WORKSPACE/rzg2l/Build/output/images/smarc-rzg2l/
+      run: ls -lah rzg2l/Build/output/images/smarc-rzg2l/
       
     - name: Upload artifacts
       uses: actions/upload-artifact@v3
       with:
         name: output-files
         path: |
-          $GITHUB_WORKSPACE/rzg2l/Build/output/images/smarc-rzg2l/mistysom-image-smarc-rzg2l.wic.bz2
-          $GITHUB_WORKSPACE/rzg2l/Build/output/images/smarc-rzg2l/mistysom-image-smarc-rzg2l.ext4.bz2
+          rzg2l/Build/output/images/smarc-rzg2l/mistysom-image-smarc-rzg2l.wic.bz2
+          rzg2l/Build/output/images/smarc-rzg2l/mistysom-image-smarc-rzg2l.ext4.bz2

--- a/.github/workflows/build-yocto.yml
+++ b/.github/workflows/build-yocto.yml
@@ -34,6 +34,9 @@ jobs:
     
     - name: Run the Docker image and build output files with SDK
       run: cd $GITHUB_WORKSPACE/rzg2l/Build && ./run.sh -c /home/github/rzg2l-cache;
+
+    - name: List files that are generated
+      run: ls -lah $GITHUB_WORKSPACE/rzg2l/Build/output/images/smarc-rzg2l/
       
     - name: Upload artifacts
       uses: actions/upload-artifact@v3

--- a/recipes-core/images/mistysom-image.bb
+++ b/recipes-core/images/mistysom-image.bb
@@ -8,6 +8,8 @@ inherit core-image features_check
 inherit extrausers
 
 REQUIRED_DISTRO_FEATURES = "wayland"
+IMAGE_FSTYPES = "wic.bz2 ext4.bz2"
+IMAGE_BOOT_FILES = "*.bin *.dtb"
 
 ##Set rootfs  to 200MiB by default
 #IMAGE_OVERHEAD_FACTOR ?= "1.0"

--- a/recipes-core/images/mistysom-image.bb
+++ b/recipes-core/images/mistysom-image.bb
@@ -8,8 +8,19 @@ inherit core-image features_check
 inherit extrausers
 
 REQUIRED_DISTRO_FEATURES = "wayland"
+
+# What extensions would the image generate in the output directory
 IMAGE_FSTYPES = "wic.bz2 ext4.bz2"
-IMAGE_BOOT_FILES = "*.bin *.dtb"
+
+# Set what to include in /boot partition of wic.bz2
+IMAGE_BOOT_FILES = "Image-*.bin r9*.dtb"
+
+# Add device tree files in /boot directory of ext4.bz2
+do_copy_dtb() {
+  cp ${DEPLOY_DIR_IMAGE}/r9*.dtb ${IMAGE_ROOTFS}/boot/
+}
+addtask do_copy_dtb before do_rootfs
+IMAGE_PREPROCESS_COMMAND += "do_copy_dtb;"
 
 ##Set rootfs  to 200MiB by default
 #IMAGE_OVERHEAD_FACTOR ?= "1.0"

--- a/recipes-core/images/mistysom-image.bb
+++ b/recipes-core/images/mistysom-image.bb
@@ -10,12 +10,12 @@ inherit extrausers
 REQUIRED_DISTRO_FEATURES = "wayland"
 
 # What extensions would the image generate in the output directory
-IMAGE_FSTYPES = "wic.bz2 ext4.bz2"
+IMAGE_FSTYPES = "wic.bz2"
 
-# Set what to include in /boot partition of wic.bz2
-IMAGE_BOOT_FILES = "Image-*.bin r9*.dtb"
+# Set what to include in boot partition of wic.bz2
+IMAGE_BOOT_FILES = "Image* r9*.dtb"
 
-# Add device tree files in /boot directory of ext4.bz2
+# Add device tree files in /boot directory of rootfs
 do_copy_dtb() {
   mkdir -p ${IMAGE_ROOTFS}/boot/
   cp ${DEPLOY_DIR_IMAGE}/r9*.dtb ${IMAGE_ROOTFS}/boot/

--- a/recipes-core/images/mistysom-image.bb
+++ b/recipes-core/images/mistysom-image.bb
@@ -17,6 +17,7 @@ IMAGE_BOOT_FILES = "Image-*.bin r9*.dtb"
 
 # Add device tree files in /boot directory of ext4.bz2
 do_copy_dtb() {
+  mkdir -p ${IMAGE_ROOTFS}/boot/
   cp ${DEPLOY_DIR_IMAGE}/r9*.dtb ${IMAGE_ROOTFS}/boot/
 }
 addtask do_copy_dtb before do_rootfs

--- a/recipes-core/images/mistysom-image.wks
+++ b/recipes-core/images/mistysom-image.wks
@@ -2,5 +2,5 @@
 # long-description: Creates a partitioned SD card image. Boot files
 # are located in the first vfat partition.
 
-part /boot --source bootimg-partition --ondisk mmcblk0 --fstype=vfat --label boot --active --align 4 --size 300
-part / --source rootfs --ondisk mmcblk0 --fstype=ext4 --label root --align 4
+part /boot --source bootimg-partition --fstype=vfat --label boot --active --align 4 --size 300
+part / --source rootfs --fstype=ext4 --label root --align 4

--- a/recipes-core/images/mistysom-image.wks
+++ b/recipes-core/images/mistysom-image.wks
@@ -2,5 +2,5 @@
 # long-description: Creates a partitioned SD card image. Boot files
 # are located in the first vfat partition.
 
-part /boot --source bootimg-partition --ondisk mmcblk1 --fstype=vfat --label boot --active --align 4 --size 300
-part / --source rootfs --ondisk mmcblk1 --fstype=ext4 --label root --align 4
+part --source bootimg-partition --fstype=vfat --label boot --active --align 4 --size 300
+part --source rootfs --fstype=ext4 --label root --align 4

--- a/recipes-core/images/mistysom-image.wks
+++ b/recipes-core/images/mistysom-image.wks
@@ -1,0 +1,6 @@
+# short-description: Create SD card image with a boot partition
+# long-description: Creates a partitioned SD card image. Boot files
+# are located in the first vfat partition.
+
+part /boot --source bootimg-partition --ondisk mmcblk0 --fstype=vfat --label boot --active --align 4 --size 300
+part / --source rootfs --ondisk mmcblk0 --fstype=ext4 --label root --align 4

--- a/recipes-core/images/mistysom-image.wks
+++ b/recipes-core/images/mistysom-image.wks
@@ -2,5 +2,5 @@
 # long-description: Creates a partitioned SD card image. Boot files
 # are located in the first vfat partition.
 
-part /boot --source bootimg-partition --fstype=vfat --label boot --active --align 4 --size 300
-part / --source rootfs --fstype=ext4 --label root --align 4
+part /boot --source bootimg-partition --ondisk mmcblk1 --fstype=vfat --label boot --active --align 4 --size 300
+part / --source rootfs --ondisk mmcblk1 --fstype=ext4 --label root --align 4


### PR DESCRIPTION
In this pull request, I am changing the image deploy output to `wic.bz2` and `ext4.bz2`.

The reason behind the `bz2` additional extension is that the file sizes go beyond 900 MB which is not suitable for download and upload.

* The `wic.bz2` file can be written into **an SD card** with the command below which creates two partitions for boot and root:
  ```
  pv mistysom-image-smarc-rzg2l.wic.bz2 | bzcat | sudo dd bs=4M of=/dev/sdX
  ```
* The `ext4.bz2` file can be written into **an eMMC storage** with the command below which creates only one partition for root:
  ```
  pv mistysom-image-smarc-rzg2l.ext4.bz2 | bzcat | sudo dd bs=4M of=/dev/sdX
  ```