### PR TITLE
Fix the dead WiFi after soft-reboots

### DIFF
--- a/recipes-core/images/mistysom-image.bb
+++ b/recipes-core/images/mistysom-image.bb
@@ -20,7 +20,6 @@ do_copy_dtb() {
   mkdir -p ${IMAGE_ROOTFS}/boot/
   cp ${DEPLOY_DIR_IMAGE}/r9*.dtb ${IMAGE_ROOTFS}/boot/
 }
-addtask do_copy_dtb before do_rootfs
 IMAGE_PREPROCESS_COMMAND += "do_copy_dtb;"
 
 ##Set rootfs  to 200MiB by default

--- a/recipes-kernel/linux/dts/0002-add-sdhi1-laird.patch
+++ b/recipes-kernel/linux/dts/0002-add-sdhi1-laird.patch
@@ -1,5 +1,5 @@
 diff --git a/arch/arm64/boot/dts/renesas/rz-smarc-common.dtsi b/arch/arm64/boot/dts/renesas/rz-smarc-common.dtsi
-index 3216ab6..35df65c 100644
+index 3216ab6..c2cbcba 100644
 --- a/arch/arm64/boot/dts/renesas/rz-smarc-common.dtsi
 +++ b/arch/arm64/boot/dts/renesas/rz-smarc-common.dtsi
 @@ -262,10 +262,20 @@
@@ -24,3 +24,28 @@ index 3216ab6..35df65c 100644
  };
  
  &spi1 {
+diff --git a/arch/arm64/boot/dts/renesas/rzg2l-smarc-som.dtsi b/arch/arm64/boot/dts/renesas/rzg2l-smarc-som.dtsi
+index c5973d8..b658bf7 100644
+--- a/arch/arm64/boot/dts/renesas/rzg2l-smarc-som.dtsi
++++ b/arch/arm64/boot/dts/renesas/rzg2l-smarc-som.dtsi
+@@ -252,18 +252,10 @@
+ 		};
+ 	};
+ 
+-	/*
+-	 * SD0 device selection is XOR between GPIO_SD0_DEV_SEL and SW1[2]
+-	 * The below switch logic can be used to select the device between
+-	 * eMMC and microSD, after setting GPIO_SD0_DEV_SEL to high in DT.
+-	 * SW1[2] should be at position 2/OFF to enable 64 GB eMMC
+-	 * SW1[2] should be at position 3/ON to enable uSD card CN3
+-	 */
+-	sd0-dev-sel-hog {
+-		gpio-hog;
++	wl_reg_on {
+ 		gpios = <RZG2L_GPIO(41, 1) GPIO_ACTIVE_HIGH>;
+ 		output-high;
+-		line-name = "sd0_dev_sel";
++		line-name = "wl_reg_on";
+ 	};
+ 
+ 	sdhi0_emmc_pins: sd0emmc {

--- a/recipes-network/drivers/files/wl-reset.service
+++ b/recipes-network/drivers/files/wl-reset.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=Reset GPIO pin for WL_REG_ON
+DefaultDependencies=no
+After=final.target
+
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/gpioset gpiochip0 329=0
+
+[Install]
+WantedBy=final.target

--- a/recipes-network/drivers/kernel-module-lwb5p-backports-laird.bbappend
+++ b/recipes-network/drivers/kernel-module-lwb5p-backports-laird.bbappend
@@ -1,4 +1,16 @@
 
+inherit systemd
+
+FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
+SRC_URI += "file://wl-reset.service"
+SYSTEMD_SERVICE_${PN} += "wl-reset.service"
+FILES_${PN} += "${systemd_system_unitdir}/wl-reset.service"
+
+do_install_append() {
+    install -d ${D}${systemd_system_unitdir}
+    install -m 0644 ${B}/../wl-reset.service ${D}${systemd_system_unitdir}
+}
+
 # Failed attempt to add other wifi modules with the command below
 # BACKPORTS_CONFIG = "defconfig-wifi"
 


### PR DESCRIPTION
In this pull request, I reset the WL_REG_ON pin (P41_1 = 329) on soft-reboot. As a result, the Laird WiFi works when the reboot command is executed.

I don't know why but this is the only way that allowed me to keep using the Wifi.

I tried to reset the pin during boot time before the kernel module is loaded, and even inside u-boot (before the kernel is loaded). But they didn't work.

