### PR TITLE
Add docker-ce to mistysom-image

### DIFF
--- a/recipes-core/images/mistysom-image.bbappend
+++ b/recipes-core/images/mistysom-image.bbappend
@@ -66,3 +66,6 @@ IMAGE_INSTALL_append = " net-tools"
 IMAGE_INSTALL_append = " tcpdump"
 IMAGE_INSTALL_append = " iputils"
 IMAGE_INSTALL_append = " tmux"
+
+# For Docker
+IMAGE_INSTALL_append = " docker-ce"


### PR DESCRIPTION
This pull request adds docker to the meta-mistysom submodule only.

Of course the virtualization layer should be enabled on the rzg2l and rzv2l for it to work.