### PR TITLE
Enable the rtmp plugin in Gstreamer

### DIFF
--- a/recipes-drpai/gstreamer1.0-drpai/gstreamer1.0-plugins-bad_%.bbappend
+++ b/recipes-drpai/gstreamer1.0-drpai/gstreamer1.0-plugins-bad_%.bbappend
@@ -1,0 +1,1 @@
+PACKAGECONFIG += "rtmp"


### PR DESCRIPTION
To run `rtmpsink` with `gst-launch`, I need the plugin to be enabled.